### PR TITLE
Fix Process.Start

### DIFF
--- a/WinDirStat.Net.Wpf.Base/Services/OSService.cs
+++ b/WinDirStat.Net.Wpf.Base/Services/OSService.cs
@@ -53,6 +53,7 @@ namespace WinDirStat.Net.Services {
 				Arguments = string.Join(" ", Environment.GetCommandLineArgs().Select(a => "\"" + a + "\"")),
 				WorkingDirectory = Directory.GetCurrentDirectory(),
 				Verb = "runas",
+                UseShellExecute = true
 			};
 			Process.Start(startInfo).Dispose();
 		}
@@ -67,6 +68,7 @@ namespace WinDirStat.Net.Services {
 		public void RunItem(string file) {
 			ProcessStartInfo startInfo = new ProcessStartInfo {
 				FileName = file,
+                UseShellExecute = true
 			};
 			Process.Start(startInfo)?.Dispose();
 		}

--- a/WinDirStat.Net.Wpf.Single/Windows/ErrorMessageBox.xaml.cs
+++ b/WinDirStat.Net.Wpf.Single/Windows/ErrorMessageBox.xaml.cs
@@ -171,7 +171,7 @@ namespace WinDirStat.Net.Wpf.Windows {
 		}
 
 		private void OnRequestNavigate(object sender, RequestNavigateEventArgs e) {
-			Process.Start((sender as Hyperlink).NavigateUri.ToString());
+			Process.Start(new ProcessStartInfo((sender as Hyperlink).NavigateUri.ToString()) { UseShellExecute = true });
 		}
 
 		#endregion


### PR DESCRIPTION
 With .NET 6, `UseShellExecute` default value is false and it will faill opening files