### PR TITLE
Fix deleting file

### DIFF
--- a/WinDirStat.Net.Wpf.Base/Model/Files/FolderItem.cs
+++ b/WinDirStat.Net.Wpf.Base/Model/Files/FolderItem.cs
@@ -536,7 +536,7 @@ namespace WinDirStat.Net.Model.Files {
 		/// </param>
 		public void RemoveItem(FileItemBase item, ref FolderItem fileCollection/*, ref FileItem firstFile*/) {
 			if (Type == FileItemType.FileCollection)
-				throw new InvalidOperationException($"Cannot call {nameof(AddItem)} from a File Collection!");
+				throw new InvalidOperationException($"Cannot call {nameof(RemoveItem)} from a File Collection!");
 
 			lock (children) {
 				if (item.Type == FileItemType.File) {


### PR DESCRIPTION
It's throwing when you delete a file from a file collection:

![image](https://github.com/jzebedee/WinDirStat.Net/assets/15875066/6972e78b-8b63-471d-bd4e-cdd6e8ff66b6)

To work around the issue, I'm now calling the refresh on the parent.

NB: It seems line endings are not correct and it's missing up the diff.

